### PR TITLE
Refactor headers for cross‑platform build

### DIFF
--- a/Classes.h
+++ b/Classes.h
@@ -1,11 +1,15 @@
 #pragma once
 
 #include <cstdint>
-#include <corecrt_math.h>
-#include <intrin.h>
+#include <cmath>
+#ifdef _MSC_VER
+#  include <intrin.h>
+#endif
 #include <string>
-#include <Windows.h>
-#include <d3d9types.h>
+
+using BOOL = bool;
+using WORD = uint16_t;
+using UINT = unsigned int;
 
 #define M_PI 3.14159265359
 #define UCONST_PI 3.1415926
@@ -31,9 +35,9 @@ typedef struct D3DXMATRIX : public D3DMATRIX
 {
 public:
 	D3DXMATRIX() {};
-	D3DXMATRIX(CONST double*);
-	D3DXMATRIX(CONST D3DMATRIX&);
-	D3DXMATRIX(CONST WORD*);
+	D3DXMATRIX(const double*);
+	D3DXMATRIX(const D3DMATRIX&);
+	D3DXMATRIX(const WORD*);
 	D3DXMATRIX(double _11, double _12, double _13, double _14,
 		double _21, double _22, double _23, double _24,
 		double _31, double _32, double _33, double _34,
@@ -46,12 +50,12 @@ public:
 
 	// casting operators
 	operator double* ();
-	operator CONST double* () const;
+	operator const double* () const;
 
 	// assignment operators
-	D3DXMATRIX& operator *= (CONST D3DXMATRIX&);
-	D3DXMATRIX& operator += (CONST D3DXMATRIX&);
-	D3DXMATRIX& operator -= (CONST D3DXMATRIX&);
+	D3DXMATRIX& operator *= (const D3DXMATRIX&);
+	D3DXMATRIX& operator += (const D3DXMATRIX&);
+	D3DXMATRIX& operator -= (const D3DXMATRIX&);
 	D3DXMATRIX& operator *= (double);
 	D3DXMATRIX& operator /= (double);
 
@@ -60,16 +64,16 @@ public:
 	D3DXMATRIX operator - () const;
 
 	// binary operators
-	D3DXMATRIX operator * (CONST D3DXMATRIX&) const;
-	D3DXMATRIX operator + (CONST D3DXMATRIX&) const;
-	D3DXMATRIX operator - (CONST D3DXMATRIX&) const;
+	D3DXMATRIX operator * (const D3DXMATRIX&) const;
+	D3DXMATRIX operator + (const D3DXMATRIX&) const;
+	D3DXMATRIX operator - (const D3DXMATRIX&) const;
 	D3DXMATRIX operator * (double) const;
 	D3DXMATRIX operator / (double) const;
 
-	friend D3DXMATRIX operator * (double, CONST D3DXMATRIX&);
+	friend D3DXMATRIX operator * (double, const D3DXMATRIX&);
 
-	BOOL operator == (CONST D3DXMATRIX&) const;
-	BOOL operator != (CONST D3DXMATRIX&) const;
+	BOOL operator == (const D3DXMATRIX&) const;
+	BOOL operator != (const D3DXMATRIX&) const;
 
 } D3DXMATRIX, * LPD3DXMATRIX;
 


### PR DESCRIPTION
## Summary
- replace nonstandard corecrt header with `<cmath>`
- remove Windows and d3d9 header usage
- define small Win32 types in `Classes.h`
- make `intrin.h` optional for MSVC
- cleanup CONST usage

## Testing
- `clang++ --target=aarch64-linux-gnu -c classes.cpp -I. -std=c++17`

------
https://chatgpt.com/codex/tasks/task_e_68429231a7308327a892090000dba17c